### PR TITLE
RCL-2 updated to openhab 3.2.0

### DIFF
--- a/org.openhab.binding.wmbus.tools/pom.xml
+++ b/org.openhab.binding.wmbus.tools/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
-    <artifactId>wmbus</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.2.0</version>
   </parent>
 
   <groupId>org.openhab.addons.bundles</groupId>

--- a/org.openhab.binding.wmbus/pom.xml
+++ b/org.openhab.binding.wmbus/pom.xml
@@ -6,8 +6,8 @@
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
-    <artifactId>wmbus</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.2.0</version>
   </parent>
 
   <groupId>org.openhab.addons.bundles</groupId>

--- a/org.openhab.binding.wmbus/src/main/history/dependencies.xml
+++ b/org.openhab.binding.wmbus/src/main/history/dependencies.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.binding.wmbus-3.1.0-SNAPSHOT">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.binding.wmbus-3.2.0">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.wmbus/3.1.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.wmbus/3.2.0</bundle>
         <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.2.1</bundle>
     </feature>
 </features>


### PR DESCRIPTION
- updated dependencies to support openhab 3.2.0